### PR TITLE
decouple tunnel drop from nodejs gc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,11 @@ crate-type = ["cdylib"]
 
 [dependencies]
 bytes = "1.3.0"
+lazy_static = "1.4.0"
 # Default enable napi4 feature, see https://nodejs.org/api/n-api.html#node-api-version-matrix
 napi = { version = "2.10.6", default-features = false, features = ["napi4", "tokio_rt"] }
 napi-derive = "2.9.3"
-ngrok = { version = "0.8.0" }
+ngrok = { version = "0.9.0" }
 tokio = { version = "1.23.0", features = ["sync"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }

--- a/examples/ngrok-get-socket.js
+++ b/examples/ngrok-get-socket.js
@@ -8,6 +8,5 @@ const ngrok = require('@ngrok/ngrok')
 ngrok.getSocket().then((socket) => {
   console.log("tunnel url: " + socket.tunnel.url());
   server.listen(socket);
-  server.tunnel = socket.tunnel; // prevent garbage collection
 });
 

--- a/examples/ngrok-http-full.js
+++ b/examples/ngrok-http-full.js
@@ -45,4 +45,4 @@ builder.connect().then((session) => {
       console.log("established tunnel at: " + tunnel.url())
       tunnel.forwardUnix(UNIX_SOCKET);
   })
-}).await;
+});

--- a/examples/ngrok-http-full.js
+++ b/examples/ngrok-http-full.js
@@ -14,6 +14,7 @@ console.log('Node.js web server at ' + UNIX_SOCKET + ' is running..');
 
 // setup ngrok
 var ngrok = require('@ngrok/ngrok');
+// import ngrok from '@ngrok/ngrok' // if inside a module
 builder = new ngrok.NgrokSessionBuilder();
 builder
   // .authtoken("<authtoken>")
@@ -21,13 +22,12 @@ builder
   .metadata("Online in One Line");
 
 builder.connect().then((session) => {
-  http.ngrok_session = session; // prevent garbage collection
   session.httpEndpoint()
-    // .allowCidrString("0.0.0.0/0")
+    // .allowCidr("0.0.0.0/0")
     // .basicAuth("ngrok", "online1line")
     // .circuitBreaker(0.5)
     // .compression()
-    // .denyCidrString("10.1.1.1/32")
+    // .denyCidr("10.1.1.1/32")
     // .domain("<somedomain>.ngrok.io")
     // .mutualTlsca(fs.readFileSync('domain.crt'))
     // .oauth("google", ["<user>@<domain>"], ["<domain>"], ["<scope>"])
@@ -42,7 +42,6 @@ builder.connect().then((session) => {
     // .webhookVerification("twilio", "asdf"),
     .metadata("example tunnel metadata from nodejs")
     .listen().then((tunnel) => {
-      http.tunnel = tunnel; // prevent garbage collection
       console.log("established tunnel at: " + tunnel.url())
       tunnel.forwardUnix(UNIX_SOCKET);
   })

--- a/examples/ngrok-http-minimum.js
+++ b/examples/ngrok-http-minimum.js
@@ -11,4 +11,4 @@ new ngrok.NgrokSessionBuilder().authtokenFromEnv().connect().then((session) => {
     console.log('tunnel at: ' + tunnel.url());
     tunnel.forwardTcp('localhost:8081');
   })
-}).await;
+});

--- a/examples/ngrok-http-minimum.js
+++ b/examples/ngrok-http-minimum.js
@@ -7,9 +7,7 @@ http.createServer(
 
 var ngrok = require('@ngrok/ngrok');
 new ngrok.NgrokSessionBuilder().authtokenFromEnv().connect().then((session) => {
-  http.ngrok_session = session; // prevent garbage collection
   session.httpEndpoint().listen().then((tunnel) => {
-    http.tunnel = tunnel; // prevent garbage collection
     console.log('tunnel at: ' + tunnel.url());
     tunnel.forwardTcp('localhost:8081');
   })

--- a/examples/ngrok-labeled.js
+++ b/examples/ngrok-labeled.js
@@ -26,4 +26,4 @@ builder.connect().then((session) => {
       console.log("established tunnel at: " + JSON.stringify(tunnel.labels()))
       tunnel.forwardUnix(UNIX_SOCKET);
   })
-}).await;
+});

--- a/examples/ngrok-labeled.js
+++ b/examples/ngrok-labeled.js
@@ -19,12 +19,10 @@ builder.authtokenFromEnv()
   .metadata("Online in One Line");
 
 builder.connect().then((session) => {
-  http.ngrok_session = session; // prevent garbage collection
   session.labeledTunnel()
     .label("edge", "edghts_<edge_id>")
     .metadata("example tunnel metadata from nodejs")
     .listen().then((tunnel) => {
-      http.tunnel = tunnel; // prevent garbage collection
       console.log("established tunnel at: " + JSON.stringify(tunnel.labels()))
       tunnel.forwardUnix(UNIX_SOCKET);
   })

--- a/examples/ngrok-tcp.js
+++ b/examples/ngrok-tcp.js
@@ -31,4 +31,4 @@ builder.connect().then((session) => {
       console.log("established tunnel at: " + tunnel.url())
       tunnel.forwardUnix(UNIX_SOCKET);
   })
-}).await;
+});

--- a/examples/ngrok-tcp.js
+++ b/examples/ngrok-tcp.js
@@ -20,16 +20,14 @@ builder.authtokenFromEnv()
 
 var global_tunnel;
 builder.connect().then((session) => {
-  http.ngrok_session = session; // prevent garbage collection
   session.tcpEndpoint()
-    // .allowCidrString("0.0.0.0/0")
-    // .denyCidrString("10.1.1.1/32")
+    // .allowCidr("0.0.0.0/0")
+    // .denyCidr("10.1.1.1/32")
     // .forwardsTo("example nodejs")
     // .proxyProto("") // One of: "", "V1", "V2"
     // .remoteAddr("<n>.tcp.ngrok.io:<p>")
     .metadata("example tunnel metadata from nodejs")
     .listen().then((tunnel) => {
-      http.tunnel = tunnel; // prevent garbage collection
       console.log("established tunnel at: " + tunnel.url())
       tunnel.forwardUnix(UNIX_SOCKET);
   })

--- a/examples/ngrok-tls.js
+++ b/examples/ngrok-tls.js
@@ -28,11 +28,11 @@ builder.connect().then((session) => {
     // .mutualTlsca(fs.readFileSync('ca.crt'))
     // .proxyProto("") // One of: "", "V1", "V2"
     // .remoteAddr("<n>.tcp.ngrok.io:<p>")
-    .certPem(fs.readFileSync('domain.crt'))
-    .keyPem(fs.readFileSync('domain.key'))
+    .termination(fs.readFileSync('domain.crt'),
+      fs.readFileSync('domain.key'))
     .metadata("example tunnel metadata from nodejs")
     .listen().then((tunnel) => {
       console.log("established tunnel at: " + tunnel.url())
       tunnel.forwardUnix(UNIX_SOCKET);
   })
-}).await;
+});

--- a/examples/ngrok-tls.js
+++ b/examples/ngrok-tls.js
@@ -19,11 +19,10 @@ builder.authtokenFromEnv()
   .metadata("Online in One Line");
 
 builder.connect().then((session) => {
-  http.ngrok_session = session; // prevent garbage collection
   console.log("established session");
   session.tlsEndpoint()
-    // .allowCidrString("0.0.0.0/0")
-    // .denyCidrString("10.1.1.1/32")
+    // .allowCidr("0.0.0.0/0")
+    // .denyCidr("10.1.1.1/32")
     // .domain("<somedomain>.ngrok.io")
     // .forwardsTo("example nodejs")
     // .mutualTlsca(fs.readFileSync('ca.crt'))
@@ -33,7 +32,6 @@ builder.connect().then((session) => {
     .keyPem(fs.readFileSync('domain.key'))
     .metadata("example tunnel metadata from nodejs")
     .listen().then((tunnel) => {
-      http.tunnel = tunnel; // prevent garbage collection
       console.log("established tunnel at: " + tunnel.url())
       tunnel.forwardUnix(UNIX_SOCKET);
   })

--- a/index.d.ts
+++ b/index.d.ts
@@ -52,6 +52,7 @@ export class NgrokSession {
   tlsEndpoint(): NgrokTlsTunnelBuilder
   /** Start building a labeled tunnel. */
   labeledTunnel(): NgrokLabeledTunnelBuilder
+  closeTunnel(id: string): Promise<void>
 }
 /**r" An ngrok tunnel backing an HTTP endpoint. */
 export class NgrokHttpTunnel {
@@ -65,6 +66,8 @@ export class NgrokHttpTunnel {
   forwardTcp(addr: string): Promise<void>
   /** Forward incoming tunnel connections to the provided Unix socket path. */
   forwardUnix(addr: string): Promise<void>
+  /** Close the tunnel. */
+  close(): Promise<void>
 }
 /**r" An ngrok tunnel backing a TCP endpoint. */
 export class NgrokTcpTunnel {
@@ -78,6 +81,8 @@ export class NgrokTcpTunnel {
   forwardTcp(addr: string): Promise<void>
   /** Forward incoming tunnel connections to the provided Unix socket path. */
   forwardUnix(addr: string): Promise<void>
+  /** Close the tunnel. */
+  close(): Promise<void>
 }
 /**r" An ngrok tunnel bcking a TLS endpoint. */
 export class NgrokTlsTunnel {
@@ -91,6 +96,8 @@ export class NgrokTlsTunnel {
   forwardTcp(addr: string): Promise<void>
   /** Forward incoming tunnel connections to the provided Unix socket path. */
   forwardUnix(addr: string): Promise<void>
+  /** Close the tunnel. */
+  close(): Promise<void>
 }
 /**r" A labeled ngrok tunnel. */
 export class NgrokLabeledTunnel {
@@ -102,6 +109,8 @@ export class NgrokLabeledTunnel {
   forwardTcp(addr: string): Promise<void>
   /** Forward incoming tunnel connections to the provided Unix socket path. */
   forwardUnix(addr: string): Promise<void>
+  /** Close the tunnel. */
+  close(): Promise<void>
 }
 /**r" An ngrok tunnel backing an HTTP endpoint. */
 export class NgrokHttpTunnelBuilder {
@@ -159,12 +168,12 @@ export class NgrokHttpTunnelBuilder {
    * Restriction placed on the origin of incoming connections to the edge to only allow these CIDR ranges.
    * Call multiple times to add additional CIDR ranges.
    */
-  allowCidrString(cidr: string): this
+  allowCidr(cidr: string): this
   /**
    * Restriction placed on the origin of incoming connections to the edge to deny these CIDR ranges.
    * Call multiple times to add additional CIDR ranges.
    */
-  denyCidrString(cidr: string): this
+  denyCidr(cidr: string): this
   /** The version of PROXY protocol to use with this tunnel, None if not using. */
   proxyProto(proxyProto: string): this
   /**
@@ -185,12 +194,12 @@ export class NgrokTcpTunnelBuilder {
    * Restriction placed on the origin of incoming connections to the edge to only allow these CIDR ranges.
    * Call multiple times to add additional CIDR ranges.
    */
-  allowCidrString(cidr: string): this
+  allowCidr(cidr: string): this
   /**
    * Restriction placed on the origin of incoming connections to the edge to deny these CIDR ranges.
    * Call multiple times to add additional CIDR ranges.
    */
-  denyCidrString(cidr: string): this
+  denyCidr(cidr: string): this
   /** The version of PROXY protocol to use with this tunnel, None if not using. */
   proxyProto(proxyProto: string): this
   /**
@@ -206,12 +215,7 @@ export class NgrokTlsTunnelBuilder {
   /** Certificates to use for client authentication at the ngrok edge. */
   mutualTlsca(mutualTlsca: Uint8Array): this
   /** The key to use for TLS termination at the ngrok edge in PEM format. */
-  keyPem(keyPem: Uint8Array): this
-  /**
-   * The certificate to use for TLS termination at the ngrok edge in PEM
-   * format.
-   */
-  certPem(certPem: Uint8Array): this
+  termination(certPem: Uint8Array, keyPem: Uint8Array): this
   /** Tunnel-specific opaque metadata. Viewable via the API. */
   metadata(metadata: string): this
   /** Begin listening for new connections on this tunnel. */
@@ -220,12 +224,12 @@ export class NgrokTlsTunnelBuilder {
    * Restriction placed on the origin of incoming connections to the edge to only allow these CIDR ranges.
    * Call multiple times to add additional CIDR ranges.
    */
-  allowCidrString(cidr: string): this
+  allowCidr(cidr: string): this
   /**
    * Restriction placed on the origin of incoming connections to the edge to deny these CIDR ranges.
    * Call multiple times to add additional CIDR ranges.
    */
-  denyCidrString(cidr: string): this
+  denyCidr(cidr: string): this
   /** The version of PROXY protocol to use with this tunnel, None if not using. */
   proxyProto(proxyProto: string): this
   /**

--- a/index.js
+++ b/index.js
@@ -284,7 +284,7 @@ async function getSocket(tunnel) {
   }
   // use tcp socket with random local port
   const server = new net.Server();
-  server.listen(0);
+  await server.listen(0);
   // forward to this socket
   tunnel.forwardTcp('localhost:' + server.address().port);
   // surface to caller
@@ -301,20 +301,21 @@ async function ngrokListen(server, tunnel) {
   // todo: named pipe on windows: https://nodejs.org/api/net.html#ipc-support
 
   // attempt unix socket
-  ngrokLinkUnix(tunnel, server)
-    .then(() => {})
-    .catch(function(err) {
-      console.debug("Using TCP socket. " + err);
-      // fallback to tcp socket
-      ngrokLinkTcp(tunnel, server);
-    });
+  try {
+    await ngrokLinkUnix(tunnel, server);
+  } catch (err) {
+    console.debug("Using TCP socket. " + err);
+    // fallback to tcp socket
+    await ngrokLinkTcp(tunnel, server);
+  }
 
   server.tunnel = tunnel; // surface to caller
+  return tunnel;
 }
 
 async function ngrokLinkTcp(tunnel, server) {
   // random local port
-  server.listen(0);
+  await server.listen(0);
   // forward to socket
   tunnel.forwardTcp('localhost:' + server.address().port);
 }
@@ -337,7 +338,7 @@ async function ngrokLinkUnix(tunnel, server) {
   }
 
   // begin listening
-  server.listen({path: filename});
+  await server.listen({path: filename});
   // tighten permissions
   try {
     fs.chmodSync(filename, fs.constants.S_IRWXU);

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "devDependencies": {
     "@napi-rs/cli": "^2.14.1",
     "ava": "^4.3.3",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "segfault-handler": "^1.3.0"
   },
   "ava": {
     "timeout": "3m"

--- a/scripts/gc-node-drop.js
+++ b/scripts/gc-node-drop.js
@@ -1,0 +1,38 @@
+// run with: node --trace-gc --expose-gc
+const SegfaultHandler = require('../node_modules/segfault-handler');
+SegfaultHandler.registerHandler('crash.log');
+
+const http = require('http');
+http.createServer(
+  function(req,res){res.writeHead(200);
+  res.write('Hello');
+  res.end();
+} ).listen(8081); 
+
+var ngrok = require('..');
+// turn on debug
+process.env.NGROK_LOG = 'ngrok_js=debug';
+ngrok.tracingSubscriber();
+
+new ngrok.NgrokSessionBuilder().authtokenFromEnv().connect().then((session) => {
+  session.httpEndpoint().listen().then((tunnel) => {
+    tunnel.forwardTcp('localhost:8081').await;
+    console.log("tunnel: " + tunnel.url() + " id: " + tunnel.id());
+    setTimeout(function () {
+      console.log('\n\n=====> running gc');
+      global.gc();
+    }, 2000);
+
+    setTimeout(function () {
+      console.log('\n\n=====> closing and nulling tunnel');
+      tunnel.close().await;
+      tunnel = null;
+    }, 4000);
+
+    setTimeout(function () {
+      console.log('\n\n=====> running gc');
+      global.gc();
+    }, 6000);
+
+  });
+}).await;

--- a/scripts/gc-rust-drop.js
+++ b/scripts/gc-rust-drop.js
@@ -1,0 +1,43 @@
+// run with: node --trace-gc --expose-gc
+const SegfaultHandler = require('segfault-handler');
+SegfaultHandler.registerHandler('crash.log');
+
+const http = require('http');
+http.createServer(
+  function(req,res){res.writeHead(200);
+  res.write('Hello');
+  res.end();
+} ).listen(8081); 
+
+var ngrok = require('/Users/bob/projects/ngrok-js/index.js');
+// turn on debug
+process.env.NGROK_LOG = 'ngrok_js=debug';
+ngrok.tracingSubscriber();
+
+new ngrok.NgrokSessionBuilder().authtokenFromEnv().connect().then((session) => {
+  session.httpEndpoint().listen().then((tunnel) => {
+    tunnel.forwardTcp('localhost:8081').await;
+    const tun_id = tunnel.id();
+    console.log("tunnel: " + tunnel.url() + " id: " + tun_id);
+    console.log('\n\n=====> nulling tunnel');
+    tunnel = null; // nodejs can gc
+
+    setTimeout(function () {
+      console.log('\n\n=====> running gc');
+      global.gc();
+    }, 2000);
+
+    setTimeout(function () {
+      console.log('\n\n=====> closing tunnel');
+      session.closeTunnel(tun_id).await;
+    }, 4000);
+
+    setTimeout(function () {
+      console.log('\n\n=====> nulling session, running gc');
+      session = null;
+      global.gc();
+    }, 6000);
+
+  });
+}).await;
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,15 @@
+use napi::{
+    Error,
+    Status,
+};
+
 pub mod http;
 pub mod session;
 pub mod tcp;
 pub mod tls;
 pub mod tunnel;
 pub mod tunnel_builder;
+
+pub(crate) fn napi_err(message: impl Into<String>) -> Error {
+    Error::new(Status::GenericFailure, message.into())
+}

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -24,21 +24,11 @@ impl NgrokTlsTunnelBuilder {
     }
     /// The key to use for TLS termination at the ngrok edge in PEM format.
     #[napi]
-    pub fn key_pem(&mut self, key_pem: Uint8Array) -> &Self {
-        self.tunnel_builder = self
-            .tunnel_builder
-            .clone()
-            .key_pem(Bytes::from(key_pem.to_vec()));
-        self
-    }
-    /// The certificate to use for TLS termination at the ngrok edge in PEM
-    /// format.
-    #[napi]
-    pub fn cert_pem(&mut self, cert_pem: Uint8Array) -> &Self {
-        self.tunnel_builder = self
-            .tunnel_builder
-            .clone()
-            .cert_pem(Bytes::from(cert_pem.to_vec()));
+    pub fn termination(&mut self, cert_pem: Uint8Array, key_pem: Uint8Array) -> &Self {
+        self.tunnel_builder = self.tunnel_builder.clone().termination(
+            Bytes::from(cert_pem.to_vec()),
+            Bytes::from(key_pem.to_vec()),
+        );
         self
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,6 +28,7 @@ __metadata:
     "@napi-rs/cli": ^2.14.1
     ava: ^4.3.3
     express: ^4.18.2
+    segfault-handler: ^1.3.0
   languageName: unknown
   linkType: soft
 
@@ -330,6 +331,15 @@ __metadata:
   version: 2.2.0
   resolution: "binary-extensions@npm:2.2.0"
   checksum: ccd267956c58d2315f5d3ea6757cf09863c5fc703e50fbeb13a7dc849b812ef76e3cf9ca8f35a0c48498776a7478d7b4a0418e1e2b8cb9cb9731f2922aaad7f8
+  languageName: node
+  linkType: hard
+
+"bindings@npm:^1.2.1":
+  version: 1.5.0
+  resolution: "bindings@npm:1.5.0"
+  dependencies:
+    file-uri-to-path: 1.0.0
+  checksum: 65b6b48095717c2e6105a021a7da4ea435aa8d3d3cd085cb9e85bcb6e5773cf318c4745c3f7c504412855940b585bdf9b918236612a1c7a7942491de176f1ae7
   languageName: node
   linkType: hard
 
@@ -937,6 +947,13 @@ __metadata:
     escape-string-regexp: ^5.0.0
     is-unicode-supported: ^1.2.0
   checksum: 08564c70ec6be8dbd26e24e4f35bacb8d9beb729b3b7faa9cd7ad54f5232b7f9a39f788a847ec45677664d568c86323001d1042482d089c0d0f311e197ad1148
+  languageName: node
+  linkType: hard
+
+"file-uri-to-path@npm:1.0.0":
+  version: 1.0.0
+  resolution: "file-uri-to-path@npm:1.0.0"
+  checksum: b648580bdd893a008c92c7ecc96c3ee57a5e7b6c4c18a9a09b44fb5d36d79146f8e442578bc0e173dc027adf3987e254ba1dfd6e3ec998b7c282873010502144
   languageName: node
   linkType: hard
 
@@ -1721,6 +1738,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nan@npm:^2.14.0":
+  version: 2.17.0
+  resolution: "nan@npm:2.17.0"
+  dependencies:
+    node-gyp: latest
+  checksum: ec609aeaf7e68b76592a3ba96b372aa7f5df5b056c1e37410b0f1deefbab5a57a922061e2c5b369bae9c7c6b5e6eecf4ad2dac8833a1a7d3a751e0a7c7f849ed
+  languageName: node
+  linkType: hard
+
 "negotiator@npm:0.6.3, negotiator@npm:^0.6.3":
   version: 0.6.3
   resolution: "negotiator@npm:0.6.3"
@@ -2096,6 +2122,17 @@ __metadata:
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
   checksum: cab8f25ae6f1434abee8d80023d7e72b598cf1327164ddab31003c51215526801e40b66c5e65d658a0af1e9d6478cadcb4c745f4bd6751f97d8644786c0978b0
+  languageName: node
+  linkType: hard
+
+"segfault-handler@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "segfault-handler@npm:1.3.0"
+  dependencies:
+    bindings: ^1.2.1
+    nan: ^2.14.0
+    node-gyp: latest
+  checksum: 253860dd1e07492bb288a66366f146241b6d69e5cbac0f8f0076bb30fc4f28be94519451cad2cca6452352bba9c46b627fb69d953f5a7b523ae083eece234118
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The customer-facing feature is that the user no longer has to keep around a reference to the javascript object that wraps the underlying tunnel to prevent the tunnel from shutting down. This case can be common, as an http server is listening to a tcp/unix socket and doesn't require a reference to the tunnel wrapper. The above is accomplished by keeping a reference to the underlying tunnel on the rust side to prevent premature dropping.

This PR also adds `tunnel.close()` and `session.closeTunnel()` so the user can explicitly shut tunnels down. These calls also remove the rust reference to the underlying tunnel, returning control of dropping the tunnel and session to when NodeJS garbage collects the wrappers.