### PR TITLE
completely decouple tunnel drop from nodejs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,7 @@ jobs:
           - host: windows-latest
             target: aarch64-pc-windows-msvc
             # target not supported by the 'ring' rust dependency (ssl library partially built by gcc)
+            # https://github.com/briansmith/ring/issues/1167
             if: false
             build: yarn build --target aarch64-pc-windows-msvc
   build-freebsd:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.0.0"
 crate-type = ["cdylib"]
 
 [dependencies]
+async-trait = "0.1.59"
 bytes = "1.3.0"
 lazy_static = "1.4.0"
 # Default enable napi4 feature, see https://nodejs.org/api/n-api.html#node-api-version-matrix

--- a/scripts/gc-rust-drop.js
+++ b/scripts/gc-rust-drop.js
@@ -4,7 +4,7 @@ if (typeof global.gc !== 'function') {
   process.exit();
 };
 
-const SegfaultHandler = require('segfault-handler');
+const SegfaultHandler = require('../node_modules/segfault-handler');
 SegfaultHandler.registerHandler('crash.log');
 
 const http = require('http');
@@ -14,7 +14,7 @@ http.createServer(
   res.end();
 } ).listen(8081); 
 
-var ngrok = require('/Users/bob/projects/ngrok-js/index.js');
+var ngrok = require('..');
 // turn on debug
 ngrok.consoleLog();
 


### PR DESCRIPTION
This takes care of an issue seen inside a SIGINT handler during NodeJS shutdown that only occurs on windows. There have been enough issues with the spawn-on-drop for tunnel that it will be nice to completely remove it from NodeJS's control going forward.