### PR TITLE
laying the groundwork for ngrok.connect(map)

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -64,28 +64,28 @@ impl NgrokHttpTunnelBuilder {
         self
     }
 
-    /// with_request_header adds a header to all requests to this edge.
+    /// request_header adds a header to all requests to this edge.
     #[napi]
     pub fn request_header(&mut self, name: String, value: String) -> &Self {
         let mut builder = self.tunnel_builder.lock();
         *builder = builder.clone().request_header(name, value);
         self
     }
-    /// with_response_header adds a header to all responses coming from this edge.
+    /// response_header adds a header to all responses coming from this edge.
     #[napi]
     pub fn response_header(&mut self, name: String, value: String) -> &Self {
         let mut builder = self.tunnel_builder.lock();
         *builder = builder.clone().response_header(name, value);
         self
     }
-    /// with_remove_request_header removes a header from requests to this edge.
+    /// remove_request_header removes a header from requests to this edge.
     #[napi]
     pub fn remove_request_header(&mut self, name: String) -> &Self {
         let mut builder = self.tunnel_builder.lock();
         *builder = builder.clone().remove_request_header(name);
         self
     }
-    /// with_remove_response_header removes a header from responses from this edge.
+    /// remove_response_header removes a header from responses from this edge.
     #[napi]
     pub fn remove_response_header(&mut self, name: String) -> &Self {
         let mut builder = self.tunnel_builder.lock();
@@ -104,6 +104,7 @@ impl NgrokHttpTunnelBuilder {
 
     /// OAuth configuration.
     /// If not called, OAuth is disabled.
+    /// https://ngrok.com/docs/cloud-edge/modules/oauth/
     #[napi]
     pub fn oauth(
         &mut self,

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -23,7 +23,7 @@ impl NgrokTlsTunnelBuilder {
             .mutual_tlsca(Bytes::from(mutual_tlsca.to_vec()));
         self
     }
-    /// The key to use for TLS termination at the ngrok edge in PEM format.
+    /// The certificate and key to use for TLS termination at the ngrok edge in PEM format.
     #[napi]
     pub fn termination(&mut self, cert_pem: Uint8Array, key_pem: Uint8Array) -> &Self {
         let mut builder = self.tunnel_builder.lock();


### PR DESCRIPTION
Adds `ngrok.authtoken(token)`, a session connection callback, and storing urls and sessions alongside tunnels to aid in lookups and closing. This lays the groundwork for the next PR: https://github.com/ngrok/ngrok-js/pull/43