### PR TITLE
Move to a single tunnel type for simplicity

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -185,7 +185,7 @@ export function authtoken(authtoken: string): Promise<void>
 /**
  * The builder for an ngrok session.
  *
- * @group Sessions
+ * @group Tunnel and Sessions
  */
 export class NgrokSessionBuilder {
   /** Create a new session builder */
@@ -323,7 +323,7 @@ export class NgrokSessionBuilder {
 /**
  * An ngrok session.
  *
- * @group Sessions
+ * @group Tunnel and Sessions
  */
 export class NgrokSession {
   /** Start building a tunnel backing an HTTP endpoint. */
@@ -339,11 +339,7 @@ export class NgrokSession {
   /** Close the ngrok session. */
   close(): Promise<void>
 }
-/**
- * Container for UpdateRequest information.
- *
- * @group Sessions
- */
+/** Container for UpdateRequest information. */
 export class UpdateRequest {
   /** The version that the agent is requested to update to. */
   version: string
@@ -351,125 +347,15 @@ export class UpdateRequest {
   permitMajorVersion: boolean
 }
 /**
- *r" An ngrok tunnel backing an HTTP endpoint.
- *r"
- *r" @group Tunnels
+ * An ngrok tunnel.
+ *
+ * @group Tunnel and Sessions
  */
-export class NgrokHttpTunnel {
+export class NgrokTunnel {
   /** The URL that this tunnel backs. */
-  url(): string
+  url(): string | null
   /** The protocol of the endpoint that this tunnel backs. */
-  proto(): string
-  /** Returns a tunnel's unique ID. */
-  id(): string
-  /**
-   * Returns a human-readable string presented in the ngrok dashboard
-   * and the Tunnels API. Use the [HttpTunnelBuilder::forwards_to],
-   * [TcpTunnelBuilder::forwards_to], etc. to set this value
-   * explicitly.
-   */
-  forwardsTo(): string
-  /** Returns the arbitrary metadata string for this tunnel. */
-  metadata(): string
-  /** Forward incoming tunnel connections to the provided TCP address. */
-  forwardTcp(addr: string): Promise<void>
-  /**
-   * Forward incoming tunnel connections to the provided file socket path.
-   * On Linux/Darwin addr can be a unix domain socket path, e.g. "/tmp/ngrok.sock"
-   * On Windows addr can be a named pipe, e.e. "\\.\pipe\an_ngrok_pipe"
-   */
-  forwardPipe(addr: string): Promise<void>
-  /**
-   * Close the tunnel.
-   *
-   * This is an RPC call that must be `.await`ed.
-   * It is equivalent to calling `Session::close_tunnel` with this
-   * tunnel's ID.
-   */
-  close(): Promise<void>
-}
-/**
- *r" An ngrok tunnel backing a TCP endpoint.
- *r"
- *r" @group Tunnels
- */
-export class NgrokTcpTunnel {
-  /** The URL that this tunnel backs. */
-  url(): string
-  /** The protocol of the endpoint that this tunnel backs. */
-  proto(): string
-  /** Returns a tunnel's unique ID. */
-  id(): string
-  /**
-   * Returns a human-readable string presented in the ngrok dashboard
-   * and the Tunnels API. Use the [HttpTunnelBuilder::forwards_to],
-   * [TcpTunnelBuilder::forwards_to], etc. to set this value
-   * explicitly.
-   */
-  forwardsTo(): string
-  /** Returns the arbitrary metadata string for this tunnel. */
-  metadata(): string
-  /** Forward incoming tunnel connections to the provided TCP address. */
-  forwardTcp(addr: string): Promise<void>
-  /**
-   * Forward incoming tunnel connections to the provided file socket path.
-   * On Linux/Darwin addr can be a unix domain socket path, e.g. "/tmp/ngrok.sock"
-   * On Windows addr can be a named pipe, e.e. "\\.\pipe\an_ngrok_pipe"
-   */
-  forwardPipe(addr: string): Promise<void>
-  /**
-   * Close the tunnel.
-   *
-   * This is an RPC call that must be `.await`ed.
-   * It is equivalent to calling `Session::close_tunnel` with this
-   * tunnel's ID.
-   */
-  close(): Promise<void>
-}
-/**
- *r" An ngrok tunnel bcking a TLS endpoint.
- *r"
- *r" @group Tunnels
- */
-export class NgrokTlsTunnel {
-  /** The URL that this tunnel backs. */
-  url(): string
-  /** The protocol of the endpoint that this tunnel backs. */
-  proto(): string
-  /** Returns a tunnel's unique ID. */
-  id(): string
-  /**
-   * Returns a human-readable string presented in the ngrok dashboard
-   * and the Tunnels API. Use the [HttpTunnelBuilder::forwards_to],
-   * [TcpTunnelBuilder::forwards_to], etc. to set this value
-   * explicitly.
-   */
-  forwardsTo(): string
-  /** Returns the arbitrary metadata string for this tunnel. */
-  metadata(): string
-  /** Forward incoming tunnel connections to the provided TCP address. */
-  forwardTcp(addr: string): Promise<void>
-  /**
-   * Forward incoming tunnel connections to the provided file socket path.
-   * On Linux/Darwin addr can be a unix domain socket path, e.g. "/tmp/ngrok.sock"
-   * On Windows addr can be a named pipe, e.e. "\\.\pipe\an_ngrok_pipe"
-   */
-  forwardPipe(addr: string): Promise<void>
-  /**
-   * Close the tunnel.
-   *
-   * This is an RPC call that must be `.await`ed.
-   * It is equivalent to calling `Session::close_tunnel` with this
-   * tunnel's ID.
-   */
-  close(): Promise<void>
-}
-/**
- *r" A labeled ngrok tunnel.
- *r"
- *r" @group Tunnels
- */
-export class NgrokLabeledTunnel {
+  proto(): string | null
   /** The labels this tunnel was started with. */
   labels(): Record<string, string>
   /** Returns a tunnel's unique ID. */
@@ -556,7 +442,7 @@ export class NgrokHttpTunnelBuilder {
   /** Tunnel-specific opaque metadata. Viewable via the API. */
   metadata(metadata: string): this
   /** Begin listening for new connections on this tunnel. */
-  listen(bind?: boolean | undefined | null): Promise<NgrokHttpTunnel>
+  listen(bind?: boolean | undefined | null): Promise<NgrokTunnel>
   /**
    * Restriction placed on the origin of incoming connections to the edge to only allow these CIDR ranges.
    * Call multiple times to add additional CIDR ranges.
@@ -586,7 +472,7 @@ export class NgrokTcpTunnelBuilder {
   /** Tunnel-specific opaque metadata. Viewable via the API. */
   metadata(metadata: string): this
   /** Begin listening for new connections on this tunnel. */
-  listen(bind?: boolean | undefined | null): Promise<NgrokTcpTunnel>
+  listen(bind?: boolean | undefined | null): Promise<NgrokTunnel>
   /**
    * Restriction placed on the origin of incoming connections to the edge to only allow these CIDR ranges.
    * Call multiple times to add additional CIDR ranges.
@@ -620,7 +506,7 @@ export class NgrokTlsTunnelBuilder {
   /** Tunnel-specific opaque metadata. Viewable via the API. */
   metadata(metadata: string): this
   /** Begin listening for new connections on this tunnel. */
-  listen(bind?: boolean | undefined | null): Promise<NgrokTlsTunnel>
+  listen(bind?: boolean | undefined | null): Promise<NgrokTunnel>
   /**
    * Restriction placed on the origin of incoming connections to the edge to only allow these CIDR ranges.
    * Call multiple times to add additional CIDR ranges.
@@ -648,19 +534,23 @@ export class NgrokLabeledTunnelBuilder {
   /** Tunnel-specific opaque metadata. Viewable via the API. */
   metadata(metadata: string): this
   /** Begin listening for new connections on this tunnel. */
-  listen(bind?: boolean | undefined | null): Promise<NgrokLabeledTunnel>
+  listen(bind?: boolean | undefined | null): Promise<NgrokTunnel>
   /** Add a label, value pair for this tunnel. */
   label(label: string, value: string): this
 }
-/** Generate, or convert a given tunnel, into one that can be passed into net.Server.listen(). */
-export function listenable(
-  tunnel?: NgrokHttpTunnel | NgrokTcpTunnel | NgrokTlsTunnel | NgrokLabeledTunnel
-): NgrokHttpTunnel | NgrokTcpTunnel | NgrokTlsTunnel | NgrokLabeledTunnel;
-/** Start the given net.Server listening to a generated, or passed in, tunnel. */
+/**
+ * Get a listenable ngrok tunnel, suitable for passing to net.Server.listen().
+ * Uses the NGROK_AUTHTOKEN environment variable to authenticate.
+ */
+export function listenable(): NgrokTunnel;
+/**
+ * Start the given net.Server listening to a generated, or passed in, tunnel.
+ * Uses the NGROK_AUTHTOKEN environment variable to authenticate if a new tunnel is created.
+ */
 export function listen(
   server: import("net").Server,
-  tunnel?: NgrokHttpTunnel | NgrokTcpTunnel | NgrokTlsTunnel | NgrokLabeledTunnel
-): NgrokHttpTunnel | NgrokTcpTunnel | NgrokTlsTunnel | NgrokLabeledTunnel;
+  tunnel?: NgrokTunnel
+): NgrokTunnel;
 /**
  * Register a console.log callback for ngrok INFO logging.
  * Optionally set the logging level to one of ERROR, WARN, INFO, DEBUG, or TRACE.

--- a/index.js
+++ b/index.js
@@ -252,7 +252,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { connect, disconnect, kill, loggingCallback, authtoken, NgrokSessionBuilder, NgrokSession, UpdateRequest, NgrokHttpTunnel, NgrokTcpTunnel, NgrokTlsTunnel, NgrokLabeledTunnel, NgrokHttpTunnelBuilder, NgrokTcpTunnelBuilder, NgrokTlsTunnelBuilder, NgrokLabeledTunnelBuilder } = nativeBinding
+const { connect, disconnect, kill, loggingCallback, authtoken, NgrokSessionBuilder, NgrokSession, UpdateRequest, NgrokTunnel, NgrokHttpTunnelBuilder, NgrokTcpTunnelBuilder, NgrokTlsTunnelBuilder, NgrokLabeledTunnelBuilder } = nativeBinding
 
 module.exports.connect = connect
 module.exports.disconnect = disconnect
@@ -262,10 +262,7 @@ module.exports.authtoken = authtoken
 module.exports.NgrokSessionBuilder = NgrokSessionBuilder
 module.exports.NgrokSession = NgrokSession
 module.exports.UpdateRequest = UpdateRequest
-module.exports.NgrokHttpTunnel = NgrokHttpTunnel
-module.exports.NgrokTcpTunnel = NgrokTcpTunnel
-module.exports.NgrokTlsTunnel = NgrokTlsTunnel
-module.exports.NgrokLabeledTunnel = NgrokLabeledTunnel
+module.exports.NgrokTunnel = NgrokTunnel
 module.exports.NgrokHttpTunnelBuilder = NgrokHttpTunnelBuilder
 module.exports.NgrokTcpTunnelBuilder = NgrokTcpTunnelBuilder
 module.exports.NgrokTlsTunnelBuilder = NgrokTlsTunnelBuilder

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "axios": "^1.3.3",
     "express": "^4.18.2",
     "prettier": "^2.8.7",
-    "typedoc": "^0.24.6",
+    "typedoc": "^0.24.7",
     "typescript": "^4.9.5"
   },
   "ava": {

--- a/src/session.rs
+++ b/src/session.rs
@@ -65,7 +65,7 @@ pub async fn authtoken(authtoken: String) {
 
 /// The builder for an ngrok session.
 ///
-/// @group Sessions
+/// @group Tunnel and Sessions
 #[napi]
 #[allow(dead_code)]
 #[derive(Default)]
@@ -394,7 +394,7 @@ impl NgrokSessionBuilder {
 
 /// An ngrok session.
 ///
-/// @group Sessions
+/// @group Tunnel and Sessions
 #[napi(custom_finalize)]
 pub(crate) struct NgrokSession {
     #[allow(dead_code)]
@@ -468,8 +468,6 @@ impl ObjectFinalize for NgrokSession {
 }
 
 /// Container for UpdateRequest information.
-///
-/// @group Sessions
 #[derive(Clone)]
 #[napi]
 pub struct UpdateRequest {

--- a/src/tunnel_builder.rs
+++ b/src/tunnel_builder.rs
@@ -26,6 +26,7 @@ use crate::{
         NgrokLabeledTunnel,
         NgrokTcpTunnel,
         NgrokTlsTunnel,
+        NgrokTunnel,
     },
 };
 
@@ -59,7 +60,7 @@ macro_rules! make_tunnel_builder {
 
             /// Begin listening for new connections on this tunnel.
             #[napi]
-            pub async fn listen(&self, _bind: Option<bool>) -> Result<$tunnel> {
+            pub async fn listen(&self, _bind: Option<bool>) -> Result<NgrokTunnel> {
                 let session = self.session.lock().clone();
                 let tun = self.tunnel_builder.lock().clone();
                 let result = tun
@@ -69,7 +70,7 @@ macro_rules! make_tunnel_builder {
 
                 // create the wrapping tunnel object via its async new()
                 match result {
-                    Ok(raw_tun) => Ok($tunnel::new(session, raw_tun).await),
+                    Ok(raw_tun) => Ok($tunnel::new_tunnel(session, raw_tun).await),
                     Err(val) => Err(val),
                 }
             }

--- a/trailer.d.ts
+++ b/trailer.d.ts
@@ -1,12 +1,16 @@
-/** Generate, or convert a given tunnel, into one that can be passed into net.Server.listen(). */
-export function listenable(
-  tunnel?: NgrokHttpTunnel | NgrokTcpTunnel | NgrokTlsTunnel | NgrokLabeledTunnel
-): NgrokHttpTunnel | NgrokTcpTunnel | NgrokTlsTunnel | NgrokLabeledTunnel;
-/** Start the given net.Server listening to a generated, or passed in, tunnel. */
+/**
+ * Get a listenable ngrok tunnel, suitable for passing to net.Server.listen().
+ * Uses the NGROK_AUTHTOKEN environment variable to authenticate.
+ */
+export function listenable(): NgrokTunnel;
+/**
+ * Start the given net.Server listening to a generated, or passed in, tunnel.
+ * Uses the NGROK_AUTHTOKEN environment variable to authenticate if a new tunnel is created.
+ */
 export function listen(
   server: import("net").Server,
-  tunnel?: NgrokHttpTunnel | NgrokTcpTunnel | NgrokTlsTunnel | NgrokLabeledTunnel
-): NgrokHttpTunnel | NgrokTcpTunnel | NgrokTlsTunnel | NgrokLabeledTunnel;
+  tunnel?: NgrokTunnel
+): NgrokTunnel;
 /**
  * Register a console.log callback for ngrok INFO logging.
  * Optionally set the logging level to one of ERROR, WARN, INFO, DEBUG, or TRACE.

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,3 @@
+{
+    "groupOrder": ["Tunnel and Sessions", "Tunnel Builders", "Functions"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -31,7 +31,7 @@ __metadata:
     axios: ^1.3.3
     express: ^4.18.2
     prettier: ^2.8.7
-    typedoc: ^0.24.6
+    typedoc: ^0.24.7
     typescript: ^4.9.5
   languageName: unknown
   linkType: soft
@@ -2524,9 +2524,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typedoc@npm:^0.24.6":
-  version: 0.24.6
-  resolution: "typedoc@npm:0.24.6"
+"typedoc@npm:^0.24.7":
+  version: 0.24.7
+  resolution: "typedoc@npm:0.24.7"
   dependencies:
     lunr: ^2.3.9
     marked: ^4.3.0
@@ -2536,7 +2536,7 @@ __metadata:
     typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x
   bin:
     typedoc: bin/typedoc
-  checksum: 3911ef6a7736ce6655a4b22fabc5be6df8812412e209d730fd168bfa7797847897f05fed797bc16558f11ce647b20746453748ff8afe85b1375c3efe2d7b57df
+  checksum: 9ae433566cb02b96deb9eb2a9f5b23d1b199f5aeb61ca8c7e2653ff5d339fbfb4d526e024febab4f3278332978814aaa0885f1d5925ba21a441d93a611510ac3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Consolidating tunnel types was useful in ngrok-py, porting the concept to ngrok-js. Also use the new group ordering functionality in typedoc.

`index.d.ts`, `index.js`, and `yarn.lock` are generated files and can be ignored.